### PR TITLE
Vim-style control and default .bmenu file

### DIFF
--- a/src/bmenu.c
+++ b/src/bmenu.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 Brian Barto
-//
+// 
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
 // Software Foundation; either version 3 of the License, or (at your option)
@@ -175,8 +175,9 @@ int main (int argc, char *argv[]) {
 	int menuRows = getMenuRows();
 	do {
 		// Check input
-		if (input == 27) {
-			input = getchar();
+                switch(input){
+                    case 27:
+                        input = getchar();
 			input = getchar();
 			if (input == 65 && menuListOption > 1)
 				--menuListOption;
@@ -186,7 +187,22 @@ int main (int argc, char *argv[]) {
 				menuFootOption = 1;
 			else if (input == 67)
 				menuFootOption = 2;
-		}
+                        break;
+                    case 106: // 106 == j
+                        if (menuListOption < menuRows)
+			    ++menuListOption;
+                        break;
+                    case 107: // 107 == k
+                        if (menuListOption > 1)
+			    --menuListOption;
+                        break;
+                    case 104: // 104 == h
+                        menuFootOption = 1;
+                        break;
+                    case 108: // 108 == l
+                        menuFootOption = 2;
+                        break;
+                }
 
 		// Print menu with the current selection highlighted
 		printMenu(menuListOption, menuFootOption);
@@ -240,7 +256,7 @@ int loadMenuConfig(char *config) {
 		strcat(menuConfigPath, "/");
 		strcat(menuConfigPath, config);
 
-                if (!fileExists(config))
+                if (!fileExists(menuConfigPath))
                     createConfig(menuConfigPath);
 	} else {
 		strcpy(menuConfigPath, config);

--- a/src/bmenu.c
+++ b/src/bmenu.c
@@ -9,6 +9,8 @@
 #include <string.h>
 #include <stdlib.h>          // getenv()
 #include <sys/ioctl.h>       // Support for terminal dimentions
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <termios.h>         // Support for character input
 #include <unistd.h>          // execl()
 
@@ -97,6 +99,8 @@ void decorateMenu(char *);
 void printMenu(int, int);
 int getMenuRows(void);
 int getMenuCols(void);
+void createConfig(char *);
+int fileExists(char *);
 
 /***************************************************
  * Main function
@@ -235,13 +239,16 @@ int loadMenuConfig(char *config) {
 		strcpy(menuConfigPath, homeDir);
 		strcat(menuConfigPath, "/");
 		strcat(menuConfigPath, config);
+
+                if (!fileExists(config))
+                    createConfig(menuConfigPath);
 	} else {
 		strcpy(menuConfigPath, config);
 	}
 
 	FILE *menuConfig;
 	if ((menuConfig = fopen(menuConfigPath, "r")) == NULL) {
-		return 2;
+            return 2;
 	}
 
 	_Bool menuOn = 1, commandOn = 0;
@@ -289,6 +296,16 @@ int loadMenuConfig(char *config) {
 	fclose(menuConfig);
 
 	return 0;
+}
+
+void createConfig(char *menuDefaultPath) {
+    FILE *menu = fopen(menuDefaultPath, "w");
+    if (menu == NULL) 
+        return; // We will return an error to main in loadMenuConfig()
+    fprintf(menu, "Clear Screen:/usr/bin/clear\n");
+    fprintf(menu, "Dir Listing:/usr/bin/ls -l");
+    
+    fclose(menu);
 }
 
 /*************************************************
@@ -527,4 +544,10 @@ int getMenuCols(void) {
 				maxCols = cols;
 
 	return maxCols + 1;
+}
+
+int fileExists(char *filename)
+{
+    struct stat buffer;   
+    return (stat (filename, &buffer) == 0);
 }


### PR DESCRIPTION
Thought it was unfortunate that a user had to build their own .bmenu file before they could use the program. Now, if no path is given, it sees if ~/.bmenu exists. If it doesn't, it builds a sample one for them. Also, I added vim-style controls so that you don't have to rely on the arrows. 