### PR TITLE
Fixes issue #3

### DIFF
--- a/src/bmenu.c
+++ b/src/bmenu.c
@@ -271,7 +271,7 @@ void createConfig(char *menuDefaultPath) {
 		return;
 
 	fprintf(menu, "Clear Screen:/usr/bin/clear\n");
-	fprintf(menu, "Dir Listing:/usr/bin/ls -l");
+	fprintf(menu, "Dir Listing:`which ls` -l");
 	fclose(menu);
 }
 


### PR DESCRIPTION
It assumes that `ls` is located at `/usr/bin` but on my Linux Mint system, it was located at `/bin` (which is where I assume most distros keeps their ls).
It should also fix the issue on macs, which most certainly does not have ls at /usr/bin

Issue #3